### PR TITLE
Release 0.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MixedModelsSmallSample"
 uuid = "fb531da0-582c-4a62-80cc-836e12ba9c31"
-version = "0.0.5"
+version = "0.1.0"
 authors = ["Arno Strouwen", "José Núñez Ares"]
 
 [deps]

--- a/test/bioequivalence heterogeneous.jl
+++ b/test/bioequivalence heterogeneous.jl
@@ -212,10 +212,8 @@ function heterogeneous_decomposition(m, df; fa0_tol=1e-3)
         return d2G
     end
 
-    d2Vs = Matrix{Matrix{Float64}}(undef, nparams, nparams)
-    for i in 1:nparams, j in 1:nparams
-        d2Vs[i, j] = zeros(n, n)
-    end
+    zero_matrix = zeros(n, n)
+    d2Vs = fill(zero_matrix, nparams, nparams)
 
     # Only iterate FA parameters
     for (idx1, i1, j1) in fa_param_indices, (idx2, i2, j2) in fa_param_indices


### PR DESCRIPTION
## Summary
- Share zero matrix in `d2Vs` allocation instead of allocating `nparams²` individual zero matrices
- Bump version to 0.1.0